### PR TITLE
Add Fashion-MNIST

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@
 source "https://rubygems.org/"
 
 gemspec
+gem "red-datasets", github: "red-data-tools/red-datasets"

--- a/lib/datasets-gdk-pixbuf.rb
+++ b/lib/datasets-gdk-pixbuf.rb
@@ -3,4 +3,5 @@ require "datasets"
 require "datasets-gdk-pixbuf/version"
 
 require "datasets-gdk-pixbuf/cifar"
+require "datasets-gdk-pixbuf/fashion-mnist"
 require "datasets-gdk-pixbuf/mnist"

--- a/lib/datasets-gdk-pixbuf/fashion-mnist.rb
+++ b/lib/datasets-gdk-pixbuf/fashion-mnist.rb
@@ -1,7 +1,7 @@
 require_relative "mnist-pixbufable"
 
 module Datasets
-  class MNIST
+  class FashionMNIST
     class Record
       include DatasetsGdkPixbuf::MNISTPixbufable
     end

--- a/lib/datasets-gdk-pixbuf/mnist-pixbufable.rb
+++ b/lib/datasets-gdk-pixbuf/mnist-pixbufable.rb
@@ -1,0 +1,10 @@
+require "gdk_pixbuf2"
+
+module DatasetsGdkPixbuf
+  module MNISTPixbufable
+    def to_gdk_pixbuf
+      rgb_data = pixels.map{|p| [(p - 255).abs] * 3}.flatten
+      GdkPixbuf::Pixbuf.new(data: rgb_data, width: 28, height: 28)
+    end
+  end
+end

--- a/test/test-fashion-mnist.rb
+++ b/test/test-fashion-mnist.rb
@@ -1,0 +1,10 @@
+class FashionMNISTTest < Test::Unit::TestCase
+  def setup
+    @dataset = Datasets::FashionMNIST.new(type: :train)
+  end
+
+  test("#to_gdk_pixbuf") do
+    assert_equal([74, 74, 70, 70, 70, 67, 67, 67, 66, 66],
+                 @dataset.to_a.first.to_gdk_pixbuf.pixels[1960, 10])
+  end
+end


### PR DESCRIPTION
### Overview
Corresponds to Fashion-MNIST dataset

### Changes
- red-datasets modified gemfile to reference github
- ~Create `Convertible` to convert to GDK Pixbuf and share processing~
  - ~modified convert CIFAR to GDK Pixbuf by `Convertible`~
- Add `to_gdk_pixbuf` method to record of Fashion-MNIST
  - modified it to read as `MNISTPixbufable` defined for processing in common with MNIST
